### PR TITLE
Create dependabot configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 * * 6"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 5
+    groups:
+      all-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 10 * * 6"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 2
+    groups:
+      all-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    


### PR DESCRIPTION
Create custom dependabot version bumping configuration which runs every sunday at 9 am for npm packages and at 10 am for github action updates. There's a limit of 5 pull requests that can be open at the same time and also all the updates are grouped in a single pull request.